### PR TITLE
Fix weight normalization for predator avoidance

### DIFF
--- a/models/animal.py
+++ b/models/animal.py
@@ -46,9 +46,16 @@ class Animal:
         random_movement_weight = self.specie.random_movement_weight
         
 
-        weight_sum = (self.specie.separation_weight + self.specie.alignment_weight + self.specie.cohesion_weight +
-                      self.specie.avoidance_weight + self.food_weight + self.specie.mating_weight +
-                      self.specie.boundary_avoidance_weight + random_movement_weight)
+        weight_sum = (
+            self.specie.separation_weight
+            + self.specie.alignment_weight
+            + self.specie.cohesion_weight
+            + self.avoidance_weight
+            + self.food_weight
+            + self.specie.mating_weight
+            + self.specie.boundary_avoidance_weight
+            + random_movement_weight
+        )
 
         # Normalize weights
         self.separation_weight = self.specie.separation_weight / weight_sum


### PR DESCRIPTION
## Summary
- correct animal movement weight normalization to use dynamic avoidance weight

## Testing
- `python - <<'PY'
import json, yaml
from models.mapcell import MapCells
from models.environment import Environment

with open('maps/map_1.json') as f:
    map_data = json.load(f)
with open('maps/settings_map_1.json') as f:
    settings = json.load(f)
map_cell = MapCells(map_data, settings)
with open('species/config_species.yaml') as f:
    config = yaml.safe_load(f)

env = Environment(map_cell)
env.initialize_animals(config)
env.config = config
env.config['simulation']['ages'] = 1
env.simulate()
print('simulate done')
PY`

------
https://chatgpt.com/codex/tasks/task_e_6849bb825ef0832a9e21aee3fd7082a3